### PR TITLE
Cleanup with np broadcasting

### DIFF
--- a/acoular/sources.py
+++ b/acoular/sources.py
@@ -1239,10 +1239,10 @@ class DirectivityCalculator(HasTraits):
           - Need to rethink the interface to allow for more complex directivity which may vary between dimensions
     """
     #: Vector defining the forward direction of the object we are working out directivity from. Default is (0, 0, 1)
-    fwd_direction = CArray(shape=(3,), default=np.array((0.0, 0.0, 1.0)), desc='Spherical Harmonic orientation')
+    fwd_directions = CArray(shape=(3, None), default=np.array([[0.0], [0.0], [1.0]]), desc='Forward directions of object we are calulating directivity for')
 
     #: Vector defining the direction of the object we are working out direction to. Default is (0, 0, 1)
-    object_direction = CArray(shape=(3,), default=np.array((0.0, 0.0, 1.0)), desc='Spherical Harmonic orientation')
+    object_directions = CArray(shape=(3, None), default=np.array([[0.0], [0.0], [1.0]]), desc='Directions of the other objects to which we are calculating the directivity')
 
     # Method which returns a scalar value to be used to attenuate the signal
     def __call__(self):
@@ -1380,26 +1380,19 @@ class PointSourceDirectional(PointSource):
         out = np.empty((num, self.num_channels))
         # distances
         rm = self.env._r(np.array(self.loc).reshape((3, 1)), self.mics.pos).reshape(1, -1)
-        ind = (-rm / self.env.c - self.start_t + self.start) * self.sample_freq * self.up
+        ind = (-rm / self.env.c - self.start_t + self.start) * self.sample_freq
 
         i = 0
         n = self.num_samples
 
+        # object directions do not change once set
+        self.dir_calc.object_directions = -gdirs_to_source
+
         while n:
             n -= 1
             try:
-                coeffs = np.empty(self.mics.num_mics)
-
-                # @TODO: looping over mics is inefficient. DirectivityCalculator should be able to handle arrays
-                # note that self.dir_calc.object_direction does not change over time
-
-                # for m in range(self.mics.num_mics):
-                #     print(f'ind: {ind}')
-                #     rotated_forward_vec = self._calc_rotation_matrix(ind[0,:]) @ self.orientation[2]
-                #     self.dir_calc.fwd_direction, self.dir_calc.object_direction = rotated_forward_vec, -gdirs_to_source[:, m]
-                #     coeffs[m] = self.dir_calc()
-
-                print(f'rot mats: {self._calc_rotation_matrix(ind[0,:]) @ self.orientation[2]}')
+                self.dir_calc.fwd_directions = (self._calc_rotation_matrix(ind[0,:]) @ self.orientation[2]).T
+                coeffs = self.dir_calc()
 
                 out[i] = (signal[np.array(0.5 + ind * self.up, dtype=np.int64)] * coeffs) / rm
                 ind += 1.0

--- a/examples_do_not_commit/find_direction.py
+++ b/examples_do_not_commit/find_direction.py
@@ -83,26 +83,31 @@ class CardioidDirectivity(ac.DirectivityCalculator):
 def main():
 
     freq = 440
-    repetitions = 200
+    repetitions = 400
     f_sample = 44100
 
     sine_signal = ac.SineGenerator(freq = freq, sample_freq=f_sample, num_samples = freq*repetitions)
 
     # We'll keep the environment simple for now: just air at standard conditions with speed of sound 343 m/s
-    e = ac.Environment(c=343.)
+    c = 343.
+    e = ac.Environment(c=c)
+
+    rotations_per_s = 3
+    opp_phase_offset = c / rotations_per_s / 2
+    init_dist = 20
 
     m = ac.MicGeom()
-    m.pos_total = np.array([[-1, 1], # x positions, all values in m
-                            [2, 2], # y
-                            [0, 0]]) # z
+    m.pos_total = np.array([[0, 0], # x positions, all values in m
+                            [0, 0], # y
+                            [init_dist, init_dist + opp_phase_offset]]) # z
 
     # Lets try to determine direction of source and reciever. Lets first do this by using a stationary source
     # Define point source
     sine_gen = ac.PointSourceDirectional(signal = sine_signal, # the signal of the source
                                 mics = m,              # set the "array" with which to measure the sound field
-                                loc = (0, 10, -20),    # location of the source
+                                loc = (0, 0, 0),    # location of the source
                                 orientation=np.eye(3),
-                                rot_speed = np.deg2rad(360 * 3),
+                                rot_speed = np.deg2rad(360 * rotations_per_s),
                                 dir_calc = CardioidDirectivity(),
                                 env = e)               # the environment the source is moving in
 

--- a/examples_do_not_commit/find_direction.py
+++ b/examples_do_not_commit/find_direction.py
@@ -75,10 +75,10 @@ class DroneSignalGenerator( ac.SignalGenerator ):
 class CardioidDirectivity(ac.DirectivityCalculator):
 
     def __call__(self):
-        dir_n = self.fwd_direction / np.linalg.norm(self.fwd_direction)
-        mic_n = self.object_direction / np.linalg.norm(self.object_direction)
-
-        return (np.dot(dir_n, mic_n) + 1) / 2
+        fwd_norm = self.fwd_directions / np.linalg.norm(self.fwd_directions, axis=0, keepdims=True)
+        obj_dir_norm = self.object_directions / np.linalg.norm(self.object_directions, axis=0, keepdims=True)
+        dot_products = np.sum(fwd_norm * obj_dir_norm, axis=0)
+        return (dot_products + 1) / 2
 
 def main():
 

--- a/examples_do_not_commit/plot.py
+++ b/examples_do_not_commit/plot.py
@@ -6,10 +6,6 @@ from scipy.io import wavfile
 # Load the WAV file
 sample_rate, data = wavfile.read('sine_rotation.wav')  # Replace with your actual file name
 
-# If stereo, take only one channel
-if len(data.shape) == 2:
-    data = data[:, 0]
-
 # Create time axis in seconds
 duration = len(data) / sample_rate
 time = np.linspace(0., duration, len(data))


### PR DESCRIPTION
### Description
cleaning up the rotation matrix calculation and the directivity coefficient calculator to use numpy broadcasting to prevent iterating over all microphones. The script (before my changes) had a slight increase in performance (~0.1s) on my machine but was quite variable.